### PR TITLE
Fix overlay not showing live capture

### DIFF
--- a/src/utils/opencv.ts
+++ b/src/utils/opencv.ts
@@ -1,25 +1,47 @@
 let opencvLoadPromise: Promise<any> | null = null;
 
 export async function loadOpenCV(): Promise<any> {
-  if (typeof window !== "undefined" && (window as any).cv && (window as any).cv["loaded"]) {
-    return (window as any).cv;
+  const win = typeof window !== "undefined" ? (window as any) : undefined;
+  if (win && win.cv && typeof win.cv.getBuildInformation === "function") {
+    return win.cv;
   }
   if (opencvLoadPromise) return opencvLoadPromise;
 
   opencvLoadPromise = new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.async = true;
-    script.src = "https://docs.opencv.org/4.x/opencv.js";
-    script.onload = () => {
-      const waitForReady = () => {
+    const existing = document.getElementById("opencv-js");
+    if (existing) {
+      const check = () => {
         const cv = (window as any).cv;
-        if (cv && cv["ready"]) {
+        if (cv && typeof cv.getBuildInformation === "function") {
           resolve(cv);
         } else {
-          setTimeout(waitForReady, 50);
+          setTimeout(check, 50);
         }
       };
-      waitForReady();
+      check();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = "opencv-js";
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    script.src = "https://docs.opencv.org/4.x/opencv.js";
+    script.onload = () => {
+      const cv = (window as any).cv;
+      if (!cv) {
+        reject(new Error("OpenCV not found on window after load"));
+        return;
+      }
+      if (typeof cv.getBuildInformation === "function") {
+        resolve(cv);
+        return;
+      }
+      cv["onRuntimeInitialized"] = () => resolve(cv);
+      // Safety timeout in case onRuntimeInitialized never fires
+      setTimeout(() => {
+        if (typeof cv.getBuildInformation === "function") resolve(cv);
+      }, 5000);
     };
     script.onerror = () => reject(new Error("Failed to load OpenCV.js"));
     document.body.appendChild(script);


### PR DESCRIPTION
Fix overlay not updating and auto-detect returning zero by using refs for live state in the drawing loop and ensuring OpenCV is fully initialized before use.

The `requestAnimationFrame` loop in `Measure.tsx` was capturing stale state variables from its initial render closure, preventing the overlay from redrawing with updated measurement points or values. By switching to `useRef` for these dynamic values, the loop now consistently accesses the most current state, allowing the overlay to update in real-time. Additionally, the OpenCV loader was not reliably waiting for the library's runtime to be fully ready, leading to failed auto-detection attempts. The updated loader now uses `onRuntimeInitialized` and a robust check for `getBuildInformation` to ensure OpenCV is fully operational before proceeding.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0962380-a2d4-4fd2-b542-f114a8fd6468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0962380-a2d4-4fd2-b542-f114a8fd6468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

