### PR TITLE
Fix measurements page black screen

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -7,10 +7,23 @@ const STORAGE_KEYS = {
   PHOTOS: "size-seeker-photos",
 };
 
+// Helper: safely parse JSON from localStorage
+function safeReadArray<T>(key: string): T[] {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [] as T[];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    // Data may be corrupted or from an older version; reset to empty
+    try { localStorage.removeItem(key); } catch {}
+    return [] as T[];
+  }
+}
+
 // Measurements Storage
 export const getMeasurements = (): Measurement[] => {
-  const stored = localStorage.getItem(STORAGE_KEYS.MEASUREMENTS);
-  return stored ? JSON.parse(stored) : [];
+  return safeReadArray<Measurement>(STORAGE_KEYS.MEASUREMENTS);
 };
 
 export const saveMeasurement = (measurement: Measurement): void => {
@@ -33,8 +46,7 @@ export const deleteMeasurement = (id: string): void => {
 
 // Sessions Storage
 export const getSessions = (): Session[] => {
-  const stored = localStorage.getItem(STORAGE_KEYS.SESSIONS);
-  return stored ? JSON.parse(stored) : [];
+  return safeReadArray<Session>(STORAGE_KEYS.SESSIONS);
 };
 
 export const saveSession = (session: Session): void => {
@@ -57,8 +69,7 @@ export const deleteSession = (id: string): void => {
 
 // Goals Storage
 export const getGoals = (): Goal[] => {
-  const stored = localStorage.getItem(STORAGE_KEYS.GOALS);
-  return stored ? JSON.parse(stored) : [];
+  return safeReadArray<Goal>(STORAGE_KEYS.GOALS);
 };
 
 export const saveGoal = (goal: Goal): void => {


### PR DESCRIPTION
Add safe parsing for `localStorage` reads to prevent crashes on the Measurements page.

The Measurements page was crashing and displaying a black screen if `localStorage` entries for measurements, sessions, or goals were corrupted or malformed. This change introduces a `safeReadArray` helper that gracefully handles parsing errors, returning an empty array and clearing the corrupted entry, thus preventing the application from crashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-f633ba63-e269-4b24-b97a-adce827c90c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f633ba63-e269-4b24-b97a-adce827c90c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

