### PR TITLE
Fix camera measure page freeze

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:hardwareAccelerated="true"
         android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
@@ -19,7 +20,8 @@
             android:label="@string/title_activity_main"
             android:launchMode="singleTask"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
-            android:theme="@style/AppTheme.NoActionBarLaunch">
+            android:theme="@style/AppTheme.NoActionBarLaunch"
+            android:hardwareAccelerated="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Optimize Measure page rendering and enable hardware acceleration to fix Android app freezes.

The previous overlay rendering loop resized the canvas every frame and ran at maximum FPS, causing excessive main-thread work and garbage collection on Android WebViews. Throttling the loop, optimizing canvas resizing, and enabling hardware acceleration significantly reduce this overhead, addressing the reported freezing issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbdc2389-2a6d-464b-8d86-177f106ef4c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbdc2389-2a6d-464b-8d86-177f106ef4c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

