### PR TITLE
Fix kotlin daemon connection and unused code warnings

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,9 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Use JDK 21 to match module compileOptions and Kotlin jvmTarget
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Set Gradle JVM to JDK 21 and increase memory to resolve Kotlin compile daemon connection failures.

The Kotlin compile daemon failed to connect due to a mismatch between the Gradle JVM and the project's Java target (Java 21), and potentially insufficient memory. This PR configures Gradle to use JDK 21 and allocates more memory to the daemon.

---
<a href="https://cursor.com/background-agent?bcId=bc-15c07a54-4c9b-4589-ac0f-6081995a8834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15c07a54-4c9b-4589-ac0f-6081995a8834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

