### PR TITLE
Optimize measuring page and fix freezing

### DIFF
--- a/public/opencv-worker.js
+++ b/public/opencv-worker.js
@@ -104,7 +104,7 @@ self.onmessage = async (event) => {
       cv.inRange(hsv, low2, high2, mask2);
       cv.bitwise_or(mask1, mask2, mask);
 
-      const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(7, 7));
+      const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(5, 5));
       cv.morphologyEx(mask, mask, cv.MORPH_CLOSE, kernel);
       cv.morphologyEx(mask, mask, cv.MORPH_OPEN, kernel);
 

--- a/src/components/measure/MeasureDetection.tsx
+++ b/src/components/measure/MeasureDetection.tsx
@@ -86,16 +86,19 @@ export const MeasureDetection = ({
         throw new Error("Video or container not available");
       }
 
-      // Create canvas for frame capture
-      const canvas = document.createElement('canvas');
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      const ctx = canvas.getContext('2d');
+      // Create offscreen canvas when supported to reduce main-thread overhead
+      const w = video.videoWidth;
+      const h = video.videoHeight;
+      const supportsOffscreen = typeof (window as any).OffscreenCanvas !== 'undefined';
+      const canvas: HTMLCanvasElement | OffscreenCanvas = supportsOffscreen
+        ? new (window as any).OffscreenCanvas(w, h)
+        : Object.assign(document.createElement('canvas'), { width: w, height: h });
+      const ctx = (canvas as any).getContext('2d');
       
       if (!ctx) throw new Error('Could not get canvas context');
       
       ctx.drawImage(video, 0, 0);
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const imageData = ctx.getImageData(0, 0, w, h);
 
       let result;
       

--- a/src/components/measure/VisualFeedbackOverlay.tsx
+++ b/src/components/measure/VisualFeedbackOverlay.tsx
@@ -19,6 +19,7 @@ export function VisualFeedbackOverlay({
 }: VisualFeedbackOverlayProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>();
+  const needsRedrawRef = useRef<boolean>(false);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -28,14 +29,15 @@ export function VisualFeedbackOverlay({
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const render = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-
+    const drawOnce = () => {
+      needsRedrawRef.current = false;
+      // Resize only when needed
       if (canvas.width !== container.clientWidth || canvas.height !== container.clientHeight) {
         canvas.width = container.clientWidth;
         canvas.height = container.clientHeight;
       }
 
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.strokeStyle = "#ffffff";
       ctx.fillStyle = "#ffffff";
       ctx.lineWidth = 2;
@@ -55,16 +57,26 @@ export function VisualFeedbackOverlay({
       if (isRecording) {
         drawRecordingIndicator(ctx, canvas.width);
       }
-
-      animationRef.current = requestAnimationFrame(render);
     };
 
-    render();
+    const schedule = () => {
+      if (needsRedrawRef.current) return;
+      needsRedrawRef.current = true;
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      animationRef.current = requestAnimationFrame(drawOnce);
+    };
+
+    // Redraw on prop changes
+    schedule();
+
+    // Redraw on resize
+    const ro = new ResizeObserver(() => schedule());
+    ro.observe(container);
 
     return () => {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-      }
+      ro.disconnect();
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      needsRedrawRef.current = false;
     };
   }, [containerRef, measurementPoints, isRecording, detectedObjects, gridEnabled, showCrosshairs]);
 

--- a/src/pages/Measure.tsx
+++ b/src/pages/Measure.tsx
@@ -982,18 +982,20 @@ export default function Measure() {
         }
       }
 
-      // Live scanning sweep when auto-detect is enabled
+      // Live scanning sweep when auto-detect is enabled (throttled)
       if (autoDetect && mode === "live" && showScanSweep) {
         const t = performance.now() / 1000;
         const bandW = Math.max(24, Math.floor(overlay.width * 0.12));
-        const xCenter = ((t * 160) % (overlay.width + bandW)) - bandW / 2;
+        // Reduce fill calls by drawing a partial rect area only around the band
+        const xCenter = ((t * 100) % (overlay.width + bandW)) - bandW / 2; // slower animation
         const grad = ctx.createLinearGradient(xCenter - bandW / 2, 0, xCenter + bandW / 2, 0);
-        const alpha = Math.max(0, Math.min(0.4, sweepIntensity / 100));
+        const alpha = Math.max(0, Math.min(0.25, sweepIntensity / 120));
         grad.addColorStop(0, `rgba(59,130,246,0.0)`);
         grad.addColorStop(0.5, `rgba(59,130,246,${alpha})`);
         grad.addColorStop(1, `rgba(59,130,246,0.0)`);
         ctx.fillStyle = grad as any;
-        ctx.fillRect(0, 0, overlay.width, overlay.height);
+        const clipX = Math.max(0, Math.floor(xCenter - bandW));
+        ctx.fillRect(clipX, 0, Math.min(overlay.width - clipX, bandW * 2), overlay.height);
       }
 
       // Stability progress ring near tip or top-left
@@ -1029,6 +1031,11 @@ export default function Measure() {
     return () => {
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
+      }
+      // Ensure detection loop is stopped
+      if (autoDetectRafRef.current) {
+        cancelAnimationFrame(autoDetectRafRef.current);
+        autoDetectRafRef.current = null;
       }
       if (uploadedUrl) URL.revokeObjectURL(uploadedUrl);
       if (prevMaskBlobUrlRef.current) {
@@ -1843,25 +1850,30 @@ export default function Measure() {
       if (!silent) toast({ title: "Camera not ready", description: "Wait for the camera stream to start.", variant: "destructive" });
       return;
     }
+    // Prevent overlapping runs
+    if (isDetecting) return;
     setIsDetecting(true);
     try {
       const cv = await loadOpenCV();
       const w0 = video.videoWidth;
       const h0 = video.videoHeight;
-      const targetMax = 640;
+      // Bound processing resolution to reduce per-frame cost
+      const targetMax = 512;
       const scaleDown = Math.min(1, targetMax / Math.max(w0, h0));
       const w = Math.max(1, Math.round(w0 * scaleDown));
       const h = Math.max(1, Math.round(h0 * scaleDown));
 
       // Draw current frame to processing canvas
-      const procCanvas = document.createElement("canvas");
-      procCanvas.width = w;
-      procCanvas.height = h;
-      const pctx = procCanvas.getContext("2d");
+      // Use OffscreenCanvas when available to minimize main-thread layout cost
+      const supportsOffscreen = typeof (window as any).OffscreenCanvas !== 'undefined';
+      const procCanvas: HTMLCanvasElement | OffscreenCanvas = supportsOffscreen
+        ? new (window as any).OffscreenCanvas(w, h)
+        : Object.assign(document.createElement("canvas"), { width: w, height: h });
+      const pctx = (procCanvas as any).getContext("2d");
       if (!pctx) throw new Error("Canvas context unavailable");
       pctx.drawImage(video, 0, 0, w, h);
 
-      const src = cv.imread(procCanvas);
+      const src = cv.imread(procCanvas as any);
       const rgba = new cv.Mat();
       cv.cvtColor(src, rgba, cv.COLOR_RGBA2RGB);
       const hsv = new cv.Mat();
@@ -1916,7 +1928,7 @@ export default function Measure() {
       }
 
       // Morphology
-      const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(7, 7));
+      const kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, new cv.Size(5, 5));
       try {
         const tmp = new cv.Mat();
         cv.bilateralFilter(rgba, tmp, 5, 75, 75, cv.BORDER_DEFAULT);
@@ -2069,7 +2081,7 @@ export default function Measure() {
         setConfidence(confidence);
         // Update temporal edge map for snapping/stabilization via worker (fallback to main thread on failure)
         try {
-          const ctx2 = procCanvas.getContext("2d");
+          const ctx2 = (procCanvas as any).getContext("2d");
           if (ctx2) {
             const frame = ctx2.getImageData(0, 0, w, h);
             const result = await opencvWorker.edges({ width: w, height: h, imageData: frame.data });
@@ -2321,9 +2333,19 @@ export default function Measure() {
       setRetakeSuggested(false);
       return;
     }
-    const loop = async () => {
+    const targetIntervalMs = Math.max(200, detectionIntervalMs); // enforce minimum interval to avoid thrash
+    let lastTs = 0;
+    const loop = async (ts?: number) => {
       const now = performance.now();
-      if (!isDetecting && now - lastDetectTsRef.current > detectionIntervalMs) {
+      // Frame throttle using RAF timestamp and detectionIntervalMs
+      if (typeof ts === 'number') {
+        if (ts - lastTs < targetIntervalMs) {
+          autoDetectRafRef.current = requestAnimationFrame(loop);
+          return;
+        }
+        lastTs = ts;
+      }
+      if (!isDetecting && now - lastDetectTsRef.current > targetIntervalMs) {
         lastDetectTsRef.current = now;
         try {
           await detectFromLive({ silent: true });


### PR DESCRIPTION
Optimize the measuring page to prevent freezing by refactoring rendering, throttling auto-detection, and reducing image processing overhead.

The measuring page was freezing due to continuous, unthrottled operations on the main thread, including the visual overlay rendering and the auto-detection loop. This PR addresses the issue by making the overlay redraw on demand, introducing backpressure and throttling to the detection loop, and using `OffscreenCanvas` and lower resolution/kernel sizes for image processing to reduce computational load.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d42a224-986f-4bbc-aa43-63d8c4ec7dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d42a224-986f-4bbc-aa43-63d8c4ec7dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

